### PR TITLE
Create docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  ehrlichgpt:
+    build: .
+    image: ehrlichgpt
+    container_name: ehrlichgpt
+    restart: unless-stopped
+    volumes:
+      - "./conversations/:/app/conversations/"
+    environment:
+      - OPENAI_API_KEY
+      - DISCORD_BOT_TOKEN
+      - BING_SUBSCRIPTION_KEY
+      - CHROME_DRIVER_PATH
+      - BING_SEARCH_URL=https://api.bing.microsoft.com/


### PR DESCRIPTION
Hi, nice bot.

This pull request introduces a `docker-compose.yml` file, simplifying the process of running the bot. Using Docker Compose, users can easily set up and manage the bot's environment, making deployment more streamlined. With this file, users only need to setup their environment variables and run `docker-compose up -d` to launch a persistent instance of the bot, reducing the number of manual steps previously required.